### PR TITLE
Remove compiler specification

### DIFF
--- a/.cmake/Compiler/GNU.cmake
+++ b/.cmake/Compiler/GNU.cmake
@@ -23,8 +23,11 @@ ${common_flags} -O0 \
 -Wall -Wno-conversion \
 -Wno-line-truncation -Wno-error=line-truncation \
 -pedantic -fcheck=all -fbacktrace \
--ffpe-summary=all \
 -finit-real=snan")
+if (NOT "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "5")
+  set (CMAKE_Fortran_FLAGS_DEBUG "\
+-ffpe-summary=all")
+endif()
 
 # set (CMAKE_Fortran_FLAGS_DEBUG "\
 # ${common_flags} -O0 \

--- a/.cmake/Compiler/GNU.cmake
+++ b/.cmake/Compiler/GNU.cmake
@@ -26,6 +26,7 @@ ${common_flags} -O0 \
 -finit-real=snan")
 if (NOT "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "5")
   set (CMAKE_Fortran_FLAGS_DEBUG "\
+${CMAKE_Fortran_FLAGS_DEBUG} \
 -ffpe-summary=all")
 endif()
 

--- a/.cmake/Compiler/configureCompiler.cmake
+++ b/.cmake/Compiler/configureCompiler.cmake
@@ -7,9 +7,6 @@
 cmake_minimum_required (VERSION 3.8.0)
 PreventInSourceBuild()
 
-# Set Fortran compiler FOR MINERVE ONLY
-set(CMAKE_Fortran_COMPILER "/opt/rh/devtoolset-6/root/bin/gfortran")
-
 # Obtain the compiler name and check capabilities
 include(${CMAKE_Fortran_COMPILER_ID} RESULT_VARIABLE found)
 if(NOT found)

--- a/test/regression/bin/regression.sh
+++ b/test/regression/bin/regression.sh
@@ -43,7 +43,12 @@ if [ -d "./build" ]; then
 fi
 mkdir ./build
 cd ./build
-cmake -DCMAKE_BUILD_TYPE="DEBUG" ../
+if [ -z "${1}" ]; then
+  cmake -DCMAKE_BUILD_TYPE="DEBUG" ../
+else
+  echo "Specified regression compiler: ${1}"
+  cmake -DCMAKE_BUILD_TYPE="DEBUG" -DCMAKE_Fortran_COMPILER="${1}" ../
+fi
 make
 reset
 make install


### PR DESCRIPTION
+ Removed compiler specification from CMake files.
+ Removed the "ffpe-summary=all" compilation flag for GNU 4.* since some compilers, like `f95`, don't support this.
+ Allowed compiler to be specified when executing the regression script to simplify regression testing against other compilers. If not specified, CMake will use whatever it finds.