### PR TITLE
Basic OpenACC Development

### DIFF
--- a/.cmake/FindLibrary/loadMPI.cmake
+++ b/.cmake/FindLibrary/loadMPI.cmake
@@ -3,7 +3,7 @@
 # Finds and sets options for MPI usage
 #
 # ============================================================================ #
-cmake_minimum_required (VERSION 3.8.0)
+cmake_minimum_required (VERSION 3.10.0)
 
 if (${PROJECT_NAME}.MPI)
   find_package(MPI)

--- a/.cmake/FindLibrary/loadOpenACC.cmake
+++ b/.cmake/FindLibrary/loadOpenACC.cmake
@@ -7,8 +7,23 @@ cmake_minimum_required (VERSION 3.10.0)
 
 if (${PROJECT_NAME}.OpenACC)
   find_package(OpenACC)
-  if (OPENACC_FOUND)
-    # Append OpenACC compiler flags:
+
+  if (OPENACC_FOUND OR
+      (${CMAKE_VERSION} VERSION_LESS "3.25" AND
+      NOT "${OpenACC_Fortran_VERSION}" STREQUAL ""))
+    # Print that OpenACC was found (similar to how we would for higher CMake
+    # versions)
+    if (${CMAKE_VERSION} VERSION_LESS "3.25")
+      message("-- Found OpenACC: TRUE (found version \"${OpenACC_Fortran_VERSION}\")")
+    endif()
+
+    # CMake 3.16+ defines the compiler flags; they may not exist for
+    # lesser versions. We'll assume them since it's pretty consistent
+    if (${CMAKE_VERSION} VERSION_LESS "3.16")
+      set (OpenACC_Fortran_FLAGS "-fopenacc")
+    endif()
+
+    # Add OpenACC flags to debug/release flags now
     set(CMAKE_Fortran_FLAGS_DEBUG
       "${CMAKE_Fortran_FLAGS_DEBUG} ${OpenACC_Fortran_FLAGS}")
     set(CMAKE_Fortran_FLAGS_RELEASE

--- a/.cmake/FindLibrary/loadOpenACC.cmake
+++ b/.cmake/FindLibrary/loadOpenACC.cmake
@@ -8,19 +8,24 @@ cmake_minimum_required (VERSION 3.10.0)
 if (${PROJECT_NAME}.OpenACC)
   find_package(OpenACC)
 
-  if (OPENACC_FOUND OR
+  if (OpenACC_FOUND OR
       (${CMAKE_VERSION} VERSION_LESS "3.25" AND
       NOT "${OpenACC_Fortran_VERSION}" STREQUAL ""))
-    # Print that OpenACC was found (similar to how we would for higher CMake
-    # versions)
-    if (${CMAKE_VERSION} VERSION_LESS "3.25")
-      message("-- Found OpenACC: TRUE (found version \"${OpenACC_Fortran_VERSION}\")")
-    endif()
 
     # CMake 3.16+ defines the compiler flags; they may not exist for
     # lesser versions. We'll assume them since it's pretty consistent
     if (${CMAKE_VERSION} VERSION_LESS "3.16")
       set (OpenACC_Fortran_FLAGS "-fopenacc")
+    endif()
+
+    # Print that OpenACC was found (similar to how we would for higher CMake
+    # versions)
+    # Note also that older versions of CMake might not notice
+    # the correct version of OpenACC, as seen with CMake 3.14.4. Regardless,
+    # the presence of "OpenACC_Fortran_VERSION" indicates it exists. Specific
+    # version dependencies may not work properly if such implementations exist.
+    if (${CMAKE_VERSION} VERSION_LESS "3.25")
+      message("-- Found OpenACC support: ${OpenACC_Fortran_FLAGS} (found version \"${OpenACC_Fortran_VERSION}\")")
     endif()
 
     # Add OpenACC flags to debug/release flags now

--- a/.cmake/FindLibrary/loadOpenACC.cmake
+++ b/.cmake/FindLibrary/loadOpenACC.cmake
@@ -1,0 +1,23 @@
+# ============================================================================ #
+#
+# Finds and sets options for OpenACC usage
+#
+# ============================================================================ #
+cmake_minimum_required (VERSION 3.10.0)
+
+if (${PROJECT_NAME}.OpenACC)
+  find_package(OpenACC)
+  if (OPENACC_FOUND)
+    # Append OpenACC compiler flags:
+    set(CMAKE_Fortran_FLAGS_DEBUG
+      "${CMAKE_Fortran_FLAGS_DEBUG} ${OpenACC_Fortran_FLAGS}")
+    set(CMAKE_Fortran_FLAGS_RELEASE
+      "${CMAKE_Fortran_FLAGS_RELEASE} ${OpenACC_Fortran_FLAGS}")
+  else ()
+    set(${PROJECT_NAME}.OpenACC OFF)
+    message(${envNOTICE} "OpenACC suport not available")
+  endif()
+endif ()
+
+
+# ============================================================================ #

--- a/.cmake/GSM/SIM_DIR.cmake
+++ b/.cmake/GSM/SIM_DIR.cmake
@@ -27,6 +27,12 @@ if (${PROJECT_NAME}.SIM_DIR)
        "${CMAKE_SOURCE_DIR}/${simDir}/"
     )
 
+  # The simulation directory will depend on any files mentioned above.
+  # Ensure we add dependencies to those.
+    add_dependencies(${simDir}
+      "x${PROJECT_NAME}${PROJECT_VERSION_MAJOR}"
+      )
+
 endif()
 
 

--- a/.cmake/GSM/configureOptions.cmake
+++ b/.cmake/GSM/configureOptions.cmake
@@ -25,6 +25,9 @@ add_option("MPI"
 add_option("OpenMP"
   "Compile ${PROJECT_NAME} with OpenMP"
   OFF)
+add_option("OpenACC"
+  "Compile ${PROJECT_NAME} with OpenACC"
+  OFF)
 add_option("PACKAGE"
   "Package ${PROJECT_NAME}"
   ON)
@@ -56,6 +59,10 @@ endif()
 
 if(${PROJECT_NAME}.OpenMP)
   include (loadOpenMP)
+endif()
+
+if(${PROJECT_NAME}.OpenACC)
+  include (loadOpenACC)
 endif()
 
 if(${PROJECT_NAME}.PACKAGE)

--- a/.cmake/GSM/configureOptions.cmake
+++ b/.cmake/GSM/configureOptions.cmake
@@ -25,9 +25,12 @@ add_option("MPI"
 add_option("OpenMP"
   "Compile ${PROJECT_NAME} with OpenMP"
   OFF)
-add_option("OpenACC"
-  "Compile ${PROJECT_NAME} with OpenACC"
-  OFF)
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10")
+  # Note: for CMake < 3.10, just assume OpenACC is unavailable
+  add_option("OpenACC"
+    "Compile ${PROJECT_NAME} with OpenACC"
+    OFF)
+endif()
 add_option("PACKAGE"
   "Package ${PROJECT_NAME}"
   ON)

--- a/.cmake/GSM/configureOptions.cmake
+++ b/.cmake/GSM/configureOptions.cmake
@@ -19,14 +19,14 @@ add_option("BUILD_DOCS"
   "Create and install the HTML based API documentation for ${PROJECT_NAME} \
   (requires Doxygen)"
   ON)
-add_option("MPI"
-  "Compile ${PROJECT_NAME} with MPI"
-  OFF)
 add_option("OpenMP"
   "Compile ${PROJECT_NAME} with OpenMP"
   OFF)
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10")
-  # Note: for CMake < 3.10, just assume OpenACC is unavailable
+  # Note: for CMake < 3.10, just assume MPI and OpenACC are unavailable
+  add_option("MPI"
+    "Compile ${PROJECT_NAME} with MPI"
+    OFF)
   add_option("OpenACC"
     "Compile ${PROJECT_NAME} with OpenACC"
     OFF)
@@ -56,16 +56,18 @@ if(${PROJECT_NAME}.BUILD_DOCS)
   set(${PROJECT_NAME}.BUILD_DOCS ${DOXYGEN_FOUND})
 endif()
 
-if(${PROJECT_NAME}.MPI)
-  include (loadMPI)
-endif()
-
 if(${PROJECT_NAME}.OpenMP)
   include (loadOpenMP)
 endif()
 
-if(${PROJECT_NAME}.OpenACC)
-  include (loadOpenACC)
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10")
+  if(${PROJECT_NAME}.MPI)
+    include (loadMPI)
+  endif()
+
+  if(${PROJECT_NAME}.OpenACC)
+    include (loadOpenACC)
+  endif()
 endif()
 
 if(${PROJECT_NAME}.PACKAGE)

--- a/.cmake/Utils/addProjectExecutable.cmake
+++ b/.cmake/Utils/addProjectExecutable.cmake
@@ -14,17 +14,31 @@ macro(add_project_executable target sources dependencies)
     "${Green}Configuring the ${target} executable...${ColorReset}")
 
   # Add the exectable, link, and install it:
-  add_executable(${target} ${sources})
+  add_executable(${target})
+  add_executable(${PROJECT_NAME}::${target} ALIAS ${target})
+
+  target_sources(${target} PRIVATE
+    ${sources}
+    )
+
+  target_compile_definitions(
+    ${target}
+    PUBLIC
+    ${${PROJECT_NAME}_compile_definitions}
+    )
 
   # If dependencies exist, add them:
   if (dependencies)
-    target_link_libraries(${target} ${dependencies})
+    target_link_libraries(${target}
+      PRIVATE
+      ${dependencies}
+      )
   endif()
 
   # Install the executable
   install(TARGETS ${target}
     CONFIGURATIONS ${SUPPORTED_CONFIGURATIONS}
-    COMPONENT "${target} (executible)"
+    COMPONENT "${target} (executable)"
     RUNTIME DESTINATION "${CMAKE_BINARY_DIR}/bin"
     LIBRARY DESTINATION "${CMAKE_BINARY_DIR}/lib"
     ARCHIVE DESTINATION "${CMAKE_BINARY_DIR}/lib"

--- a/.cmake/Utils/addSubLibrary.cmake
+++ b/.cmake/Utils/addSubLibrary.cmake
@@ -22,7 +22,7 @@ macro (add_sublibrary target sources dependencies)
   endif()
 
   # Create the general structure for the library
-  add_library(${subtarget} "${libtype}" "")
+  add_library(${subtarget} "${lib_type}" "")
   add_library(${PROJECT_NAME}::${target} ALIAS ${subtarget})
 
   # Set library sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@
 #   GSM.BUILD_DOCS    [ON]                Creates an API documentation build target
 #   GSM.SIM_DIR       [ON]                Creates simulation directory build target
 #   GSM.MPI           [OFF]               Builds GSM with MPI enabled
+#   GSM.OpenMP        [OFF]               Builds GSM with OpenMP enabled
+#   GSM.OpenACC       [OFF]               Builds GSM with OpenACC enabled
 #   GSM.PACK          [on]                Packages GSM
 #   GSM.SHARED        [BUILD_SHARED_LIBS] Builds GSM with shared libraries
 #   GSM.TEST          [ON]                Enables testing of GSM via CTest
@@ -15,7 +17,7 @@
 #
 # ============================================================================ #
 cmake_minimum_required (VERSION 3.8.0)
-project(gsm
+project(GSM
   VERSION 1.1.0
   LANGUAGES Fortran
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@
 # GSM top-level CMakeLists.txt
 #
 # Options:
-#   GSM.BUILD_DOCS    [ON]                Creates an API documentation build target
-#   GSM.SIM_DIR       [ON]                Creates simulation directory build target
-#   GSM.MPI           [OFF]               Builds GSM with MPI enabled
-#   GSM.OpenMP        [OFF]               Builds GSM with OpenMP enabled
-#   GSM.OpenACC       [OFF]               Builds GSM with OpenACC enabled
-#   GSM.PACK          [on]                Packages GSM
-#   GSM.SHARED        [BUILD_SHARED_LIBS] Builds GSM with shared libraries
-#   GSM.TEST          [ON]                Enables testing of GSM via CTest
+#   gsm.BUILD_DOCS    [ON]                Creates an API documentation build target
+#   gsm.SIM_DIR       [ON]                Creates simulation directory build target
+#   gsm.MPI           [OFF]               Builds GSM with MPI enabled
+#   gsm.OpenMP        [OFF]               Builds GSM with OpenMP enabled
+#   gsm.OpenACC       [OFF]               Builds GSM with OpenACC enabled
+#   gsm.PACK          [on]                Packages GSM
+#   gsm.SHARED        [BUILD_SHARED_LIBS] Builds GSM with shared libraries
+#   gsm.TEST          [ON]                Enables testing of GSM via CTest
 #
 # Usage:
 #    cmake [OPTIONS] ../
@@ -17,7 +17,7 @@
 #
 # ============================================================================ #
 cmake_minimum_required (VERSION 3.8.0)
-project(GSM
+project(gsm
   VERSION 1.1.0
   LANGUAGES Fortran
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(Docs EXCLUDE_FROM_ALL)
 # Configure executable
 #
 # ============================================================================ #
+# NOTE: Simulation directory inclusion depends on this naming convention.
 set (exec "x${PROJECT_NAME}${PROJECT_VERSION_MAJOR}")
 
 # Set main executable's sources and dependencies

--- a/src/GeneralizedSpallation/gsmMain.f90
+++ b/src/GeneralizedSpallation/gsmMain.f90
@@ -692,8 +692,8 @@
        else
           write(gsmObj%io%message, 4950) "will not"
        end if
+       call gsmObj%io%print(3, 4, gsmObj%io%message)
     end if
-    call gsmObj%io%print(3, 4, gsmObj%io%message)
 
     !>>> ASSIGN TO AN OPENMP TASK
     ! Establish all modified DCM arguments:

--- a/src/Utilities/Parallel/CMakeLists.txt
+++ b/src/Utilities/Parallel/CMakeLists.txt
@@ -14,6 +14,7 @@ set(model_name "Parallel")
 # Load the sources used for the sub-model
 set(sources
   ${CMAKE_CURRENT_LIST_DIR}/OpenMPAbstraction.f90
+  ${CMAKE_CURRENT_LIST_DIR}/OpenACCAbstraction.f90
   # ${CMAKE_CURRENT_LIST_DIR}/MPI.f90
   )
 

--- a/src/Utilities/Parallel/OpenACCAbstraction.f90
+++ b/src/Utilities/Parallel/OpenACCAbstraction.f90
@@ -1,0 +1,72 @@
+! =============================================================================
+!
+!> \file
+!> \brief  Contains the abstraction for OpenACC
+!> \author CMJ (XCP-3; LANL)
+!>
+!> The module provides the abstraction layer for calls to the OpenACC library
+!> when it is defined (OpenACC) by the compiler.
+!>
+!> Note that OpenACC funcionality is only invoked when the project is compiled
+!> with the \c -fopenacc compiler flag via the \c _OPENACC preprocessor definition.
+!
+! =============================================================================
+module OpenACCAbstraction
+
+#if defined(_OPENACC)
+  use OPENACC
+#endif
+
+  ! Import Contracts
+  use Contracts
+
+  implicit none
+  private
+
+  ! Public functions
+  public :: &
+       & gpuThreadingAvailable, &
+       & numCurrentDevices
+
+contains
+
+
+! =========================================================================== !
+!
+!> \fn
+!> \brief Returns a logical flag indicating if OpenACC is available
+!
+! =========================================================================== !
+  function gpuThreadingAvailable() result(available)
+    implicit none
+    logical :: available
+#if defined(_OPENACC)
+    available = .TRUE.
+#else
+    available = .FALSE.
+#endif
+    return
+  end function gpuThreadingAvailable
+
+
+! =========================================================================== !
+!
+!> \fn
+!> \brief Returns the number of devices currently in action
+
+! =========================================================================== !
+  function numCurrentDevices() result(numDevices)
+    use, intrinsic:: iso_fortran_env, only: int32
+    implicit none
+    integer(int32) :: numDevices
+#if defined(_OPENACC)
+    numDevices = acc_get_num_devices(acc_get_device_type())
+#else
+    numDevices = 1_int32
+#endif
+    return
+  end function numCurrentDevices
+
+
+! =========================================================================== !
+end module OpenACCAbstraction


### PR DESCRIPTION
Added an option to compile GSM with OpenACC.

> OpenACC is NOT used by GSM in these changes.

Additional other changes for parallelization and CMake adjustments:
- OpenACC "find" module
- Adjusted MPI inclusion (require CMake v3.10 or higher)
- Added GSM executable as dependency of GSM simulation directory (duh!)
- Adjusted executable characteristics to be similar to those for libraries
- A few other small issues / typos corrected