### PR TITLE
Add a check to prevent rewinding if a file is closed in initam.f90.

### DIFF
--- a/src/ModifiedDCM/Data/initam.f90
+++ b/src/ModifiedDCM/Data/initam.f90
@@ -167,7 +167,9 @@
        look(i) = 0
     enddo
     if(nodcay) return
-    rewind decayUnit
+    if (decayUnit /= -1_int32) then
+        rewind decayUnit
+    endif
 
 200 loop=loop+1
     if(loop > 600) go to 9999


### PR DESCRIPTION
In some cases, `rewind decayUnit` is executed in initam.f90 when decayUnit is -1, meaning the file is closed. This may cause a segmentation fault.

The added check successfully resolves the problem while not making substantial changes to the logic of the program. 